### PR TITLE
updated claim method to include crumb + propagate parameter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyYAML
+requests


### PR DESCRIPTION
the updated jenkins instance use CSRF protection.
This requires extra step - obtaining a 'crumb' by making a get request to the issuer.
I put this just after loading the config (i didn't want to put this inside any method as it would be executed every time).
also, the claim plugin got updated, accepting 1 more parameter (propagate to other builds) - looks like not including this parameter returns err500 from the jenkins server.